### PR TITLE
Add sample script to ping google's API

### DIFF
--- a/bert_reranker/models/ping_google_model.py
+++ b/bert_reranker/models/ping_google_model.py
@@ -1,0 +1,23 @@
+import os
+import json
+import requests
+
+
+# Export your gcloud auth token to an env variable
+gcloud_auth_token = os.environ["GCLOUD_AUTH_TOKEN"]
+data = {
+    "instances": [
+        {
+            "input": "what is the main covid symptoms",
+            "candidates": ["symptoms for covid", "hi", "can my employer fire me"],
+        }
+    ]
+}
+data = json.dumps(data)
+
+url = "https://ml.googleapis.com/v1/projects/descartes-covid/models/hotline:predict?alt=json"
+headers = {"Authorization": "Bearer " + gcloud_auth_token}
+
+response = requests.post(url, data=data, headers=headers)
+if response.status_code == 200:
+    predictions = response.json()


### PR DESCRIPTION
Sample code to ping google's API via python. To export your google auth token, use

`export GCLOUD_AUTH_TOKEN=$(gcloud auth application-default print-access-token)`